### PR TITLE
Support raw system commands

### DIFF
--- a/commandparser.c
+++ b/commandparser.c
@@ -156,7 +156,7 @@ void parse_input(const char *input, CommandStruct *cmd) {
  * Locate the executable under base_path, then execv() it,
  * passing all flags (and their values) first, then positional parameters.
  */
-void execute_command(const CommandStruct *cmd) {
+int execute_command(const CommandStruct *cmd) {
     char command_path[PATH_MAX];
     int found = 0;
 
@@ -186,14 +186,14 @@ void execute_command(const CommandStruct *cmd) {
 
     if (!found) {
         fprintf(stderr, "Command not found or not executable: %s\n", cmd->command);
-        return;
+        return -1;
     }
 
     /* Resolve to absolute path */
     char abs_path[PATH_MAX];
     if (!realpath(command_path, abs_path)) {
         perror("realpath failed");
-        return;
+        return -1;
     }
 
     /* Build argv: flags+values first, then parameters */
@@ -211,7 +211,7 @@ void execute_command(const CommandStruct *cmd) {
     pid_t pid = fork();
     if (pid < 0) {
         perror("fork failed");
-        return;
+        return -1;
     }
     if (pid == 0) {
         signal(SIGINT, SIG_DFL);
@@ -220,9 +220,12 @@ void execute_command(const CommandStruct *cmd) {
         exit(EXIT_FAILURE);
     } else {
         int status;
-        if (waitpid(pid, &status, 0) < 0)
+        if (waitpid(pid, &status, 0) < 0) {
             perror("waitpid failed");
+            return -1;
+        }
     }
+    return 0;
 }
 
 /* Free all strdup’d memory in a CommandStruct */

--- a/commandparser.h
+++ b/commandparser.h
@@ -26,7 +26,7 @@ typedef struct {
 } CommandStruct;
 
 void parse_input(const char *input, CommandStruct *cmd);
-void execute_command(const CommandStruct *cmd);
+int execute_command(const CommandStruct *cmd);
 void free_command_struct(CommandStruct *cmd);
 
 /* 


### PR DESCRIPTION
## Summary
- Allow command parser to signal missing commands and return status
- Run arbitrary shell commands by default when no built-in or app matches
- Add helper to execute raw shell commands and update run command to use it

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7de1e448327b165c70292b86bd0