### PR TITLE
fix: resolve build warnings

### DIFF
--- a/commandparser.c
+++ b/commandparser.c
@@ -169,15 +169,18 @@ int execute_command(const CommandStruct *cmd) {
 
     /* Search for the executable */
     for (int i = 0; i < num_dirs; i++) {
+        int n;
         if (base_path[0] != '\0') {
-            snprintf(command_path, sizeof(command_path),
-                     "%s/%s/%s",
-                     base_path, relative_commands_dirs[i], cmd->command);
+            n = snprintf(command_path, sizeof(command_path),
+                         "%s/%s/%s",
+                         base_path, relative_commands_dirs[i], cmd->command);
         } else {
-            snprintf(command_path, sizeof(command_path),
-                     "./%s/%s",
-                     relative_commands_dirs[i], cmd->command);
+            n = snprintf(command_path, sizeof(command_path),
+                         "./%s/%s",
+                         relative_commands_dirs[i], cmd->command);
         }
+        if (n < 0 || n >= (int)sizeof(command_path))
+            continue;
         if (access(command_path, X_OK) == 0) {
             found = 1;
             break;

--- a/input.c
+++ b/input.c
@@ -343,8 +343,7 @@ static int autocomplete_filename(const char *token, char *completion, size_t com
     if (match_count == 1) {
         char full_completion[INPUT_SIZE];
         snprintf(full_completion, sizeof(full_completion), "%s%s", dir, match);
-        strncpy(completion, full_completion, completion_size - 1);
-        completion[completion_size - 1] = '\0';
+        snprintf(completion, completion_size, "%s", full_completion);
     }
     return match_count;
 }

--- a/lib/libconsole.c
+++ b/lib/libconsole.c
@@ -125,7 +125,10 @@ void login() {
     // Build the target directory relative to the current directory.
     // This path will be: "<current_dir>/users/<username>"
     char new_path[PATH_MAX];
-    snprintf(new_path, sizeof(new_path), "%s/users/%s", cwd, username);
+    if (snprintf(new_path, sizeof(new_path), "%s/users/%s", cwd, username) >= (int)sizeof(new_path)) {
+        fprintf(stderr, "path too long\n");
+        return;
+    }
 
     // Attempt to change the current working directory.
     if (chdir(new_path) != 0) {

--- a/main.c
+++ b/main.c
@@ -54,7 +54,10 @@ static char **g_argv;
  */
 void load_realtime_commands(void) {
     char apps_path[PATH_MAX];
-    snprintf(apps_path, sizeof(apps_path), "%s/apps", base_directory);
+    if (snprintf(apps_path, sizeof(apps_path), "%s/apps", base_directory) >= (int)sizeof(apps_path)) {
+        perror("snprintf");
+        return;
+    }
     DIR *dir = opendir(apps_path);
     if (!dir) {
         perror("opendir");
@@ -69,7 +72,8 @@ void load_realtime_commands(void) {
         
         /* Construct the full path to the file */
         char full_path[PATH_MAX];
-        snprintf(full_path, sizeof(full_path), "%s/%s", apps_path, entry->d_name);
+        if (snprintf(full_path, sizeof(full_path), "%s/%s", apps_path, entry->d_name) >= (int)sizeof(full_path))
+            continue;
         
         /* Check if it's a regular file and executable */
         struct stat sb;
@@ -507,7 +511,7 @@ int main(int argc, char *argv[]) {
                 *last_slash = '\0'; // Terminate the string at the last '/'
             }
             set_base_path(exe_path);
-            strncpy(base_directory, exe_path, sizeof(base_directory)-1);
+            snprintf(base_directory, sizeof(base_directory), "%s", exe_path);
         }
     }
     
@@ -515,7 +519,8 @@ int main(int argc, char *argv[]) {
     load_realtime_commands();
 
     /* Clear the screen */
-    system("clear");
+    if (system("clear") != 0)
+        perror("system");
 
     /* Modified: Determine if we need to auto-run a command. */
     char *auto_command = NULL;
@@ -533,7 +538,8 @@ int main(int argc, char *argv[]) {
     if ((argc > 1 && strcmp(argv[1], "-f") == 0) || auto_command != NULL) {
         /* Do not print startup messages and skip login() */
     } else {
-        system("clear");
+        if (system("clear") != 0)
+            perror("system");
         printlogo();
         login();
         printf("========================================================================\n");

--- a/makefile
+++ b/makefile
@@ -1,7 +1,6 @@
 # Compiler and flags
 CC = gcc
-CFLAGS = -std=c11 -Wall -Wextra -pedantic -Wno-format-truncation \
-         -O3 -march=native -ffast-math -fno-strict-aliasing
+CFLAGS = -std=c11 -Wall -Wextra -pedantic -O3 -march=native -ffast-math -fno-strict-aliasing
 LDFLAGS = -lasound -lm -pthread
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove warning suppression flags from build
- fix string truncation and unused-result warnings in core sources
- add bounds checks for generated paths to prevent buffer issues

## Testing
- `make budostack`
- `grep -n "warning" /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_68a87eca5c948327908229c00cd7e41c