### PR TITLE
Fix paint grid rendering after BMP load

### DIFF
--- a/apps/paint.c
+++ b/apps/paint.c
@@ -390,6 +390,58 @@ static void set_color_ansi(uint8_t idx){
 #endif
 }
 
+#if USE_ANSI_COLOR
+static void set_bg_color_ansi(uint8_t idx){
+    if (idx == EMPTY) {
+        write(STDOUT_FILENO, "\x1b[49m", 5);
+        return;
+    }
+    char seq[32];
+    int n = snprintf(seq, sizeof(seq), "\x1b[48;5;%dm", palette[idx].term256);
+    write(STDOUT_FILENO, seq, n);
+}
+
+static void reset_ansi_colors(void){
+    write(STDOUT_FILENO, "\x1b[39m", 5);
+    write(STDOUT_FILENO, "\x1b[49m", 5);
+}
+#else
+static void set_bg_color_ansi(uint8_t idx){ (void)idx; }
+static void reset_ansi_colors(void){}
+#endif
+
+static void draw_cell(uint8_t idx, int highlight){
+    char ch;
+    if (idx == EMPTY) {
+        ch = '.';
+        set_bg_color_ansi(EMPTY);
+#if USE_ANSI_COLOR
+        write(STDOUT_FILENO, "\x1b[39m", 5);
+#endif
+    } else if (idx < 26) {
+        ch = palette[idx].letter;
+        set_bg_color_ansi(idx);
+#if USE_ANSI_COLOR
+        write(STDOUT_FILENO, "\x1b[39m", 5);
+#endif
+    } else {
+        ch = '?';
+        set_bg_color_ansi(EMPTY);
+#if USE_ANSI_COLOR
+        write(STDOUT_FILENO, "\x1b[39m", 5);
+#endif
+    }
+
+    if (highlight) {
+        write(STDOUT_FILENO, "\x1b[7m", 4);
+    }
+    write(STDOUT_FILENO, &ch, 1);
+    if (highlight) {
+        write(STDOUT_FILENO, "\x1b[0m", 4);
+    }
+    reset_ansi_colors();
+}
+
 static void render(void){
     int rows, cols;
     get_terminal_size(&rows, &cols);
@@ -419,7 +471,7 @@ static void render(void){
         write(STDOUT_FILENO, &ch, 1);
         write(STDOUT_FILENO, " ", 1);
     }
-    write(STDOUT_FILENO, "\x1b[39m", 5);
+    reset_ansi_colors();
     // Fill to end
     int curcol = 10 + 2*26;
     int cols_now; get_terminal_size(&rows,&cols_now);
@@ -440,29 +492,11 @@ static void render(void){
 	            continue;
 	        }
 
-	        uint8_t idx = pixels[y * img_w + x];
+                uint8_t idx = pixels[y * img_w + x];
 
-	        if (x == cursor_x && y == cursor_y) {
-	            // Cursor cell (inverse video)
-	            write(STDOUT_FILENO, "\x1b[7m", 4);
-	            set_color_ansi(idx);
-	            if (idx == EMPTY) {
-	                write(STDOUT_FILENO, ".", 1);
-	            } else {
-	                write(STDOUT_FILENO, "█", 3); // U+2588
-	            }
-	            write(STDOUT_FILENO, "\x1b[0m", 4);
-	        } else {
-	            set_color_ansi(idx);
-	            if (idx == EMPTY) {
-	                write(STDOUT_FILENO, ".", 1);
-	            } else {
-	                write(STDOUT_FILENO, "█", 3); // U+2588
-	            }
-	            write(STDOUT_FILENO, "\x1b[39m", 5); // reset to default FG
-	        }
-	    }
-	}
+                draw_cell(idx, x == cursor_x && y == cursor_y);
+            }
+        }
 
     write(STDOUT_FILENO, "\r\n", 2);
     // Status


### PR DESCRIPTION
## Summary
- add helpers to manage ANSI background/reset handling for cells
- render each pixel via a shared routine that keeps the grid visible after loading BMP images

## Testing
- gcc -Wall -Wextra -std=c99 -c apps/paint.c -o /tmp/paint.o

------
https://chatgpt.com/codex/tasks/task_e_68e141c9fbf08327a33d1331a5a4279a