### PR TITLE
Preserve terminal background for overlay commands

### DIFF
--- a/commands/_BAR.c
+++ b/commands/_BAR.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
     }
     printf("\033[38;5;%dm", color);
     printf("%s %s %d%%", title, bar, progress);
-    printf("\033[0m\n");
+    printf("\033[39m\n");
     fflush(stdout);
 
     return EXIT_SUCCESS;

--- a/commands/_RECT.c
+++ b/commands/_RECT.c
@@ -138,11 +138,11 @@ int main(int argc, char *argv[]) {
         if (fill || row == 0 || row == height - 1) {
             printf("\033[38;5;%dm", color);
             printf("%s", line);
-            printf("\033[0m");
+            printf("\033[39m");
         } else {
             printf("\033[38;5;%dm", color);
             printf("%s", pixel);
-            printf("\033[0m");
+            printf("\033[39m");
 
             if (width > 1) {
                 int interior = width - 2;
@@ -152,12 +152,12 @@ int main(int argc, char *argv[]) {
 
                 printf("\033[38;5;%dm", color);
                 printf("%s", pixel);
-                printf("\033[0m");
+                printf("\033[39m");
             }
         }
     }
 
-    printf("\033[0m");
+    printf("\033[39m");
     fflush(stdout);
     free(line);
 

--- a/commands/_TEXT.c
+++ b/commands/_TEXT.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
     printf("\033[%d;%dH", row, col);
     printf("\033[38;5;%dm", color);
     fputs(text, stdout);
-    printf("\033[0m");
+    printf("\033[39m");
     fflush(stdout);
 
     exit_code = EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- avoid resetting terminal background when drawing text, bars, and rectangles
- replace full ANSI resets with foreground-only resets to preserve existing imagery

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1879d2b4c8327b1242673c9d42f36