### PR TITLE
Adjust terminal rows to fill fullscreen height

### DIFF
--- a/terminal_src/main.c
+++ b/terminal_src/main.c
@@ -417,8 +417,6 @@ static int init_renderer(TerminalRenderer *renderer)
     renderer->scale_x = 1.0f;
     renderer->scale_y = 1.0f;
 
-    renderer->logical_width = renderer->cols * renderer->char_width + TERMINAL_PADDING * 2;
-    renderer->logical_height = renderer->rows * renderer->line_height + TERMINAL_PADDING * 2;
     renderer->target_width = TERMINAL_FALLBACK_WIDTH;
     renderer->target_height = TERMINAL_FALLBACK_HEIGHT;
 
@@ -450,6 +448,15 @@ static int init_renderer(TerminalRenderer *renderer)
 
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
     SDL_GetWindowSize(renderer->window, &renderer->window_width, &renderer->window_height);
+
+    int suggested_rows = renderer->target_height / renderer->line_height;
+    if (suggested_rows < TERMINAL_DEFAULT_ROWS) {
+        suggested_rows = TERMINAL_DEFAULT_ROWS;
+    }
+    renderer->rows = suggested_rows;
+
+    renderer->logical_width = renderer->cols * renderer->char_width + TERMINAL_PADDING * 2;
+    renderer->logical_height = renderer->rows * renderer->line_height + TERMINAL_PADDING * 2;
 
     float content_scale = fminf(
         (float)renderer->target_width / (float)renderer->logical_width,
@@ -659,7 +666,7 @@ int main(int argc, char *argv[])
     }
 
     TerminalBuffer buffer;
-    if (terminal_buffer_init(&buffer, TERMINAL_MAX_LINES) == -1) {
+    if (terminal_buffer_init(&buffer, renderer.cols, renderer.rows, TERMINAL_MAX_LINES) == -1) {
         fprintf(stderr, "Failed to initialize terminal buffer: %s\n", strerror(errno));
         destroy_renderer(&renderer);
         return EXIT_FAILURE;

--- a/terminal_src/terminal_buffer.c
+++ b/terminal_src/terminal_buffer.c
@@ -649,14 +649,21 @@ static void process_byte(TerminalBuffer *buffer, unsigned char byte)
     }
 }
 
-int terminal_buffer_init(TerminalBuffer *buffer, size_t max_history_lines)
+int terminal_buffer_init(TerminalBuffer *buffer, int cols, int rows, size_t max_history_lines)
 {
     if (!buffer) {
         return -1;
     }
 
-    buffer->cols = TERMINAL_DEFAULT_COLS;
-    buffer->rows = TERMINAL_DEFAULT_ROWS;
+    if (cols <= 0) {
+        cols = TERMINAL_DEFAULT_COLS;
+    }
+    if (rows <= 0) {
+        rows = TERMINAL_DEFAULT_ROWS;
+    }
+
+    buffer->cols = cols;
+    buffer->rows = rows;
     buffer->max_history_lines = max_history_lines;
     buffer->cells = calloc((size_t)buffer->cols * (size_t)buffer->rows, sizeof(TerminalCell));
     if (!buffer->cells) {

--- a/terminal_src/terminal_buffer.h
+++ b/terminal_src/terminal_buffer.h
@@ -45,7 +45,7 @@ typedef struct {
     int utf8_bytes_remaining;
 } TerminalBuffer;
 
-int terminal_buffer_init(TerminalBuffer *buffer, size_t max_history_lines);
+int terminal_buffer_init(TerminalBuffer *buffer, int cols, int rows, size_t max_history_lines);
 void terminal_buffer_destroy(TerminalBuffer *buffer);
 int terminal_buffer_append(TerminalBuffer *buffer, const char *data, size_t length);
 const TerminalCell *terminal_buffer_cell(const TerminalBuffer *buffer, int row, int col);


### PR DESCRIPTION
## Summary
- compute the terminal row count from the fullscreen height so the console fills the available space
- allow the terminal buffer to be initialized with renderer-provided dimensions and pass the calculated size from the renderer

## Testing
- make bin/terminal *(fails: SDL2/SDL.h missing in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29c7a06f483279357f1766757c345