### PR TITLE
Add TTF font rendering and improved keyboard input

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,13 +3,21 @@ CC = gcc
 CFLAGS = -std=c11 -Wall -Wextra -Werror -Wpedantic
 SDL2_CFLAGS ?= $(shell pkg-config --cflags sdl2 2>/dev/null)
 SDL2_LIBS ?= $(shell pkg-config --libs sdl2 2>/dev/null)
+SDL2_TTF_CFLAGS ?= $(shell pkg-config --cflags SDL2_ttf 2>/dev/null)
+SDL2_TTF_LIBS ?= $(shell pkg-config --libs SDL2_ttf 2>/dev/null)
 ifeq ($(SDL2_CFLAGS),)
 SDL2_CFLAGS = -I/usr/include/SDL2 -D_REENTRANT
 endif
 ifeq ($(SDL2_LIBS),)
 SDL2_LIBS = -lSDL2
 endif
-CFLAGS += $(SDL2_CFLAGS)
+ifeq ($(SDL2_TTF_CFLAGS),)
+SDL2_TTF_CFLAGS = -I/usr/include/SDL2 -D_REENTRANT
+endif
+ifeq ($(SDL2_TTF_LIBS),)
+SDL2_TTF_LIBS = -lSDL2_ttf
+endif
+CFLAGS += $(SDL2_CFLAGS) $(SDL2_TTF_CFLAGS)
 LDFLAGS = -lasound -lm -pthread
 
 # --------------------------------------------------------------------
@@ -65,7 +73,7 @@ $(TARGET): $(NON_COMMAND_OBJECTS) $(LIB_OBJS)
 $(TERMINAL_TARGET): $(TERMINAL_OBJS)
 	@mkdir -p $(BIN_DIR)
 	@echo "Linking $@..."
-	$(CC) $(TERMINAL_OBJS) $(LDFLAGS) $(SDL2_LIBS) -lutil -o $@
+	$(CC) $(TERMINAL_OBJS) $(LDFLAGS) $(SDL2_LIBS) $(SDL2_TTF_LIBS) -lutil -o $@
 
 # For each executable, link its corresponding object file with the lib objects.
 $(COMMANDS_EXES) $(APPS_EXES) $(GAMES_EXES) $(UTILITIES_EXES): %: %.o $(LIB_OBJS)


### PR DESCRIPTION
## Summary
- add SDL_ttf font loading with fallback to the existing PSF font so the terminal can render full Unicode glyphs
- refresh the glyph cache to render TTF glyphs and broaden keyboard handling, covering general Ctrl combinations and extra navigation keys
- extend the build to pull in SDL2_ttf headers and libraries when compiling the terminal

## Testing
- `make bin/terminal` *(fails: SDL2 development headers are not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29f7a0920832784fb2d1b7a937bcc