### PR TITLE
Implement _EXE command

### DIFF
--- a/commands/_EXE.c
+++ b/commands/_EXE.c
@@ -1,9 +1,8 @@
 /*
-
 SYNTAX: _EXE -[x] -[y]
 
 DESCRIPTION:
-  
+
   With _EXE command user is able to start executable with offset given by
   [x] in columns and [y] as rows from top left corner. All output from
   executables started with _EXE follow the background color without replacing
@@ -11,3 +10,250 @@ DESCRIPTION:
   color instead of replacing it.
 
 */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../lib/termbg.h"
+
+static int parse_int(const char *value, const char *name, int *out) {
+    char *endptr = NULL;
+    errno = 0;
+    long parsed = strtol(value, &endptr, 10);
+
+    if (errno != 0 || endptr == value || *endptr != '\0') {
+        fprintf(stderr, "_EXE: invalid integer for %s: '%s'\n", name, value);
+        return -1;
+    }
+
+    if (parsed < INT_MIN || parsed > INT_MAX) {
+        fprintf(stderr, "_EXE: integer out of range for %s: '%s'\n", name, value);
+        return -1;
+    }
+
+    *out = (int)parsed;
+    return 0;
+}
+
+static void print_usage(void) {
+    fprintf(stderr, "Usage: _EXE -x <col> -y <row> [--] <command> [args...]\n");
+}
+
+static void write_char_at(int x, int y, unsigned char ch, int *last_bg) {
+    int color;
+    if (termbg_get(x, y, &color)) {
+        if (*last_bg != color) {
+            printf("\033[48;5;%dm", color);
+            *last_bg = color;
+        }
+    } else if (*last_bg != -1) {
+        printf("\033[49m");
+        *last_bg = -1;
+    }
+
+    printf("\033[%d;%dH", y + 1, x + 1);
+    fputc(ch, stdout);
+}
+
+static void reset_background(int *last_bg) {
+    if (*last_bg != -1) {
+        printf("\033[49m");
+        *last_bg = -1;
+    }
+}
+
+static int process_output(int fd, int origin_x, int origin_y) {
+    char buffer[4096];
+    int current_x = 0;
+    int current_y = 0;
+    int last_bg = -1;
+
+    for (;;) {
+        ssize_t nread = read(fd, buffer, sizeof(buffer));
+        if (nread > 0) {
+            for (ssize_t i = 0; i < nread; ++i) {
+                unsigned char ch = (unsigned char)buffer[i];
+                switch (ch) {
+                    case '\r':
+                        current_x = 0;
+                        reset_background(&last_bg);
+                        break;
+                    case '\n':
+                        current_x = 0;
+                        current_y++;
+                        reset_background(&last_bg);
+                        break;
+                    case '\t': {
+                        int spaces = 8 - (current_x % 8);
+                        if (spaces == 0)
+                            spaces = 8;
+                        for (int s = 0; s < spaces; ++s) {
+                            write_char_at(origin_x + current_x, origin_y + current_y, ' ', &last_bg);
+                            current_x++;
+                        }
+                        break;
+                    }
+                    case '\b':
+                        if (current_x > 0)
+                            current_x--;
+                        reset_background(&last_bg);
+                        break;
+                    default:
+                        if (ch < 0x20 && ch != 0x1b) {
+                            /* Skip other control characters */
+                            break;
+                        }
+                        write_char_at(origin_x + current_x, origin_y + current_y, ch, &last_bg);
+                        current_x++;
+                        break;
+                }
+            }
+            fflush(stdout);
+        } else if (nread == 0) {
+            break;
+        } else if (errno == EINTR) {
+            continue;
+        } else {
+            perror("_EXE: read");
+            reset_background(&last_bg);
+            fflush(stdout);
+            return -1;
+        }
+    }
+
+    reset_background(&last_bg);
+    fflush(stdout);
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    int x = -1;
+    int y = -1;
+    int have_x = 0;
+    int have_y = 0;
+    int command_index = -1;
+    int pipefd[2] = {-1, -1};
+    pid_t pid = -1;
+    int status = 0;
+    int exit_code = EXIT_FAILURE;
+    int output_error = 0;
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--") == 0) {
+            command_index = i + 1;
+            break;
+        } else if (!have_x && strcmp(argv[i], "-x") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "_EXE: missing value for -x\n");
+                print_usage();
+                goto cleanup;
+            }
+            if (parse_int(argv[i], "-x", &x) != 0)
+                goto cleanup;
+            have_x = 1;
+        } else if (!have_y && strcmp(argv[i], "-y") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "_EXE: missing value for -y\n");
+                print_usage();
+                goto cleanup;
+            }
+            if (parse_int(argv[i], "-y", &y) != 0)
+                goto cleanup;
+            have_y = 1;
+        } else {
+            command_index = i;
+            break;
+        }
+    }
+
+    if (command_index == -1)
+        command_index = argc;
+
+    if (!have_x || !have_y || command_index >= argc) {
+        fprintf(stderr, "_EXE: missing required arguments\n");
+        print_usage();
+        goto cleanup;
+    }
+
+    if (x < 0 || y < 0) {
+        fprintf(stderr, "_EXE: coordinates must be non-negative\n");
+        goto cleanup;
+    }
+
+    char **child_argv = &argv[command_index];
+
+    if (pipe(pipefd) != 0) {
+        perror("_EXE: pipe");
+        goto cleanup;
+    }
+
+    pid = fork();
+    if (pid < 0) {
+        perror("_EXE: fork");
+        goto cleanup;
+    }
+
+    if (pid == 0) {
+        /* Child process */
+        if (dup2(pipefd[1], STDOUT_FILENO) < 0 || dup2(pipefd[1], STDERR_FILENO) < 0) {
+            perror("_EXE: dup2");
+            _exit(EXIT_FAILURE);
+        }
+        close(pipefd[0]);
+        close(pipefd[1]);
+
+        execvp(child_argv[0], child_argv);
+        perror("_EXE: execvp");
+        _exit(EXIT_FAILURE);
+    }
+
+    close(pipefd[1]);
+    pipefd[1] = -1;
+
+    output_error = (process_output(pipefd[0], x, y) != 0);
+    close(pipefd[0]);
+    pipefd[0] = -1;
+
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR)
+            continue;
+        perror("_EXE: waitpid");
+        goto cleanup;
+    }
+
+    if (WIFEXITED(status))
+        exit_code = WEXITSTATUS(status);
+    else if (WIFSIGNALED(status))
+        exit_code = 128 + WTERMSIG(status);
+    else
+        exit_code = EXIT_FAILURE;
+
+    if (output_error)
+        exit_code = EXIT_FAILURE;
+
+    pid = -1;
+
+cleanup:
+    if (pipefd[0] != -1)
+        close(pipefd[0]);
+    if (pipefd[1] != -1)
+        close(pipefd[1]);
+    if (pid > 0) {
+        /* Ensure the child is reaped if we exited early */
+        while (waitpid(pid, NULL, 0) < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+    }
+
+    termbg_shutdown();
+
+    return exit_code;
+}


### PR DESCRIPTION
## Summary
- implement the `_EXE` command to run child processes at specified screen offsets
- stream child output while preserving background colors retrieved from `termbg`
- add robust argument parsing, error handling, and cleanup around the execution pipeline

## Testing
- make commands/_EXE

------
https://chatgpt.com/codex/tasks/task_e_68e2bc71ad3083278103fda857135e20