### PR TITLE
Update stats app to print once

### DIFF
--- a/apps/stats.c
+++ b/apps/stats.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -5,8 +7,6 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <string.h>
-#include <termios.h>
-#include <sys/select.h>
 
 // Function to get battery charge (if available)
 // Returns battery capacity (0–100) if found, or -1 if no battery is found.
@@ -52,20 +52,6 @@ int get_battery_charge(void) {
     return battery;
 }
 
-static struct termios orig_termios;
-
-static void reset_terminal_mode(void) {
-    tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
-}
-
-static void set_conio_terminal_mode(void) {
-    struct termios new_termios;
-    tcgetattr(STDIN_FILENO, &orig_termios);
-    new_termios = orig_termios;
-    new_termios.c_lflag &= ~(ICANON | ECHO);
-    tcsetattr(STDIN_FILENO, TCSANOW, &new_termios);
-}
-
 static int read_cpu_stats(unsigned long long *user, unsigned long long *nice,
                           unsigned long long *system, unsigned long long *idle,
                           unsigned long long *iowait, unsigned long long *irq,
@@ -80,141 +66,118 @@ static int read_cpu_stats(unsigned long long *user, unsigned long long *nice,
 }
 
 int main(void) {
-    set_conio_terminal_mode();
-    atexit(reset_terminal_mode);
-
     time_t start_time = time(NULL);
+    time_t now = start_time;
+    struct tm *local = localtime(&now);
+    char time_str[64];
+    if (local && strftime(time_str, sizeof(time_str), "%H:%M:%S %d-%B-%Y", local)) {
+        printf("Time: %s\n", time_str);
+    }
 
-    unsigned long long prev_user = 0, prev_nice = 0, prev_system = 0,
-                       prev_idle = 0, prev_iowait = 0, prev_irq = 0,
-                       prev_softirq = 0, prev_steal = 0;
-    int have_prev = 0;
+    struct statvfs stat;
+    if (statvfs("/", &stat) == 0) {
+        unsigned long free_bytes = stat.f_bfree * stat.f_frsize;
+        double free_gb = free_bytes / (1024.0 * 1024.0 * 1024.0);
+        printf("Free Disk Space: %.1fGB\n", free_gb);
+    }
 
-    while (1) {
-        printf("\033[H\033[J");
-
-        time_t now = time(NULL);
-        struct tm *local = localtime(&now);
-        char time_str[64];
-        if (local && strftime(time_str, sizeof(time_str), "%H:%M:%S %d-%B-%Y", local)) {
-            printf("Time: %s\n", time_str);
+    FILE *fp = fopen("/sys/class/thermal/thermal_zone0/temp", "r");
+    if (fp) {
+        int temp_millideg;
+        if (fscanf(fp, "%d", &temp_millideg) == 1) {
+            double cpu_temp = temp_millideg / 1000.0;
+            printf("CPU Temp: %.0f°C\n", cpu_temp);
         }
+        fclose(fp);
+    }
 
-        double elapsed = difftime(now, start_time);
-        int hrs = (int)elapsed / 3600;
-        int mins = ((int)elapsed % 3600) / 60;
-        int secs = (int)elapsed % 60;
-        printf("Runtime: %02d:%02d:%02d\n", hrs, mins, secs);
-
-        struct statvfs stat;
-        if (statvfs("/", &stat) == 0) {
-            unsigned long free_bytes = stat.f_bfree * stat.f_frsize;
-            double free_gb = free_bytes / (1024.0 * 1024.0 * 1024.0);
-            printf("Free Disk Space: %.1fGB\n", free_gb);
-        }
-
-        FILE *fp = fopen("/sys/class/thermal/thermal_zone0/temp", "r");
-        if (fp) {
-            int temp_millideg;
-            if (fscanf(fp, "%d", &temp_millideg) == 1) {
-                double cpu_temp = temp_millideg / 1000.0;
-                printf("CPU Temp: %.0f°C\n", cpu_temp);
+    unsigned long long user1, nice1, system1, idle1, iowait1, irq1, softirq1, steal1;
+    unsigned long long user2, nice2, system2, idle2, iowait2, irq2, softirq2, steal2;
+    double cpu_usage = -1.0;
+    if (read_cpu_stats(&user1, &nice1, &system1, &idle1, &iowait1, &irq1, &softirq1, &steal1) == 0) {
+        struct timespec req = { .tv_sec = 0, .tv_nsec = 100000000 };
+        nanosleep(&req, NULL);
+        if (read_cpu_stats(&user2, &nice2, &system2, &idle2, &iowait2, &irq2, &softirq2, &steal2) == 0) {
+            unsigned long long total1 = user1 + nice1 + system1 + idle1 + iowait1 + irq1 + softirq1 + steal1;
+            unsigned long long total2 = user2 + nice2 + system2 + idle2 + iowait2 + irq2 + softirq2 + steal2;
+            unsigned long long delta_total = total2 - total1;
+            unsigned long long delta_idle = (idle2 + iowait2) - (idle1 + iowait1);
+            if (delta_total != 0 && delta_total >= delta_idle) {
+                cpu_usage = (double)(delta_total - delta_idle) * 100.0 / delta_total;
             }
-            fclose(fp);
         }
+    }
 
-        unsigned long long user, nice, system, idle, iowait, irq, softirq, steal;
-        if (read_cpu_stats(&user, &nice, &system, &idle, &iowait, &irq, &softirq, &steal) == 0) {
-            if (have_prev) {
-                unsigned long long total = user + nice + system + idle + iowait + irq + softirq + steal;
-                unsigned long long prev_total = prev_user + prev_nice + prev_system + prev_idle + prev_iowait + prev_irq + prev_softirq + prev_steal;
-                unsigned long long delta_total = total - prev_total;
-                unsigned long long delta_idle = (idle + iowait) - (prev_idle + prev_iowait);
-                double cpu_usage = delta_total ? (double)(delta_total - delta_idle) * 100.0 / delta_total : 0.0;
-                printf("CPU Average Utilization: %.1f%%\n", cpu_usage);
-            } else {
-                printf("CPU Average Utilization: N/A\n");
-                have_prev = 1;
+    if (cpu_usage >= 0.0) {
+        printf("CPU Average Utilization: %.1f%%\n", cpu_usage);
+    } else {
+        printf("CPU Average Utilization: N/A\n");
+    }
+
+    now = time(NULL);
+    double elapsed = difftime(now, start_time);
+    int hrs = (int)elapsed / 3600;
+    int mins = ((int)elapsed % 3600) / 60;
+    int secs = (int)elapsed % 60;
+    printf("Runtime: %02d:%02d:%02d\n", hrs, mins, secs);
+
+    fp = fopen("/proc/uptime", "r");
+    if (fp) {
+        double uptime_seconds;
+        if (fscanf(fp, "%lf", &uptime_seconds) == 1) {
+            int days = (int)uptime_seconds / (24 * 3600);
+            int hours = ((int)uptime_seconds % (24 * 3600)) / 3600;
+            int minutes = (((int)uptime_seconds % 3600)) / 60;
+            int seconds = (int)uptime_seconds % 60;
+            printf("Uptime: ");
+            int printed = 0;
+            if (days > 0) {
+                printf("%d %s", days, (days == 1 ? "day" : "days"));
+                printed = 1;
             }
-            prev_user = user; prev_nice = nice; prev_system = system;
-            prev_idle = idle; prev_iowait = iowait; prev_irq = irq;
-            prev_softirq = softirq; prev_steal = steal;
-        }
-
-        fp = fopen("/proc/uptime", "r");
-        if (fp) {
-            double uptime_seconds;
-            if (fscanf(fp, "%lf", &uptime_seconds) == 1) {
-                int days = (int)uptime_seconds / (24 * 3600);
-                int hours = ((int)uptime_seconds % (24 * 3600)) / 3600;
-                int minutes = (((int)uptime_seconds % 3600)) / 60;
-                int seconds = (int)uptime_seconds % 60;
-                printf("Uptime: ");
-                int printed = 0;
-                if (days > 0) {
-                    printf("%d %s", days, (days == 1 ? "day" : "days"));
-                    printed = 1;
-                }
-                if (hours > 0) {
-                    if (printed)
-                        printf(" ");
-                    printf("%d %s", hours, (hours == 1 ? "hour" : "hours"));
-                    printed = 1;
-                }
-                if (minutes > 0) {
-                    if (printed)
-                        printf(" ");
-                    printf("%d %s", minutes, (minutes == 1 ? "minute" : "minutes"));
-                    printed = 1;
-                }
+            if (hours > 0) {
                 if (printed)
-                    printf(" and ");
-                printf("%d %s\n", seconds, (seconds == 1 ? "second" : "seconds"));
+                    printf(" ");
+                printf("%d %s", hours, (hours == 1 ? "hour" : "hours"));
+                printed = 1;
             }
-            fclose(fp);
-        }
-
-        fp = fopen("/proc/meminfo", "r");
-        if (fp) {
-            char line[256];
-            unsigned long memTotal = 0, memAvailable = 0;
-            while (fgets(line, sizeof(line), fp)) {
-                if (sscanf(line, "MemTotal: %lu kB", &memTotal) == 1)
-                    continue;
-                if (sscanf(line, "MemAvailable: %lu kB", &memAvailable) == 1)
-                    continue;
+            if (minutes > 0) {
+                if (printed)
+                    printf(" ");
+                printf("%d %s", minutes, (minutes == 1 ? "minute" : "minutes"));
+                printed = 1;
             }
-            fclose(fp);
-            if (memTotal > 0) {
-                double totalMB = memTotal / 1024.0;
-                double usedMB = (memTotal - memAvailable) / 1024.0;
-                double usedPercent = ((memTotal - memAvailable) * 100.0) / memTotal;
-                printf("Memory Usage: %.1fMB used / %.1fMB total (%.1f%%)\n", usedMB, totalMB, usedPercent);
-            }
+            if (printed)
+                printf(" and ");
+            printf("%d %s\n", seconds, (seconds == 1 ? "second" : "seconds"));
         }
+        fclose(fp);
+    }
 
-        int battery = get_battery_charge();
-        if (battery >= 0) {
-            printf("Battery Charge: %d%%\n", battery);
-        } else {
-            printf("Battery Charge: N/A\n");
+    fp = fopen("/proc/meminfo", "r");
+    if (fp) {
+        char line[256];
+        unsigned long memTotal = 0, memAvailable = 0;
+        while (fgets(line, sizeof(line), fp)) {
+            if (sscanf(line, "MemTotal: %lu kB", &memTotal) == 1)
+                continue;
+            if (sscanf(line, "MemAvailable: %lu kB", &memAvailable) == 1)
+                continue;
         }
-
-        printf("Press 'q' to quit.\n");
-        fflush(stdout);
-
-        fd_set set;
-        FD_ZERO(&set);
-        FD_SET(STDIN_FILENO, &set);
-        struct timeval tv;
-        tv.tv_sec = 1;
-        tv.tv_usec = 0;
-        int rv = select(STDIN_FILENO + 1, &set, NULL, NULL, &tv);
-        if (rv > 0) {
-            char ch;
-            if (read(STDIN_FILENO, &ch, 1) > 0 && (ch == 'q' || ch == 'Q'))
-                break;
+        fclose(fp);
+        if (memTotal > 0) {
+            double totalMB = memTotal / 1024.0;
+            double usedMB = (memTotal - memAvailable) / 1024.0;
+            double usedPercent = ((memTotal - memAvailable) * 100.0) / memTotal;
+            printf("Memory Usage: %.1fMB used / %.1fMB total (%.1f%%)\n", usedMB, totalMB, usedPercent);
         }
+    }
+
+    int battery = get_battery_charge();
+    if (battery >= 0) {
+        printf("Battery Charge: %d%%\n", battery);
+    } else {
+        printf("Battery Charge: N/A\n");
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- remove the interactive terminal handling and looping from `apps/stats.c`
- have the stats tool take a single snapshot, including CPU usage via a short delay
- compute and print runtime based on the one-shot execution

## Testing
- gcc -Wall -Wextra -std=c11 -c apps/stats.c -o /tmp/stats.o

------
https://chatgpt.com/codex/tasks/task_e_68e2c2860c948327b2250a7a7b81e01e