### PR TITLE
Add _GETROW and _GETCOL commands for cursor position

### DIFF
--- a/commands/_GETCOL.c
+++ b/commands/_GETCOL.c
@@ -1,0 +1,116 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <termios.h>
+#include <unistd.h>
+
+#define PROGRAM_NAME "_GETCOL"
+
+static int restore_terminal(int fd, const struct termios *orig) {
+    if (tcsetattr(fd, TCSANOW, orig) == -1) {
+        perror(PROGRAM_NAME ": tcsetattr");
+        return -1;
+    }
+    return 0;
+}
+
+static int query_cursor_position(int *out_row, int *out_col) {
+    if (out_row == NULL || out_col == NULL) {
+        errno = EINVAL;
+        perror(PROGRAM_NAME ": invalid output pointer");
+        return -1;
+    }
+
+    if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) {
+        fprintf(stderr, PROGRAM_NAME ": stdin and stdout must be a terminal\n");
+        return -1;
+    }
+
+    struct termios orig;
+    if (tcgetattr(STDIN_FILENO, &orig) == -1) {
+        perror(PROGRAM_NAME ": tcgetattr");
+        return -1;
+    }
+
+    struct termios raw = orig;
+    raw.c_lflag &= ~(ICANON | ECHO);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 10; /* 1 second timeout */
+
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) == -1) {
+        perror(PROGRAM_NAME ": tcsetattr");
+        return -1;
+    }
+
+    int status = -1;
+
+    if (fflush(stdout) == EOF) {
+        perror(PROGRAM_NAME ": fflush");
+        goto restore;
+    }
+
+    const char query[] = "\033[6n";
+    ssize_t written = write(STDOUT_FILENO, query, sizeof(query) - 1);
+    if (written != (ssize_t)(sizeof(query) - 1)) {
+        if (written == -1)
+            perror(PROGRAM_NAME ": write");
+        else
+            fprintf(stderr, PROGRAM_NAME ": short write when querying cursor\n");
+        goto restore;
+    }
+
+    char response[64];
+    size_t len = 0;
+    int timeouts = 0;
+    int done = 0;
+
+    while (len < sizeof(response) - 1 && timeouts < 5) {
+        ssize_t nread = read(STDIN_FILENO, response + len, sizeof(response) - 1 - len);
+        if (nread > 0) {
+            len += (size_t)nread;
+            if (response[len - 1] == 'R') {
+                done = 1;
+                break;
+            }
+        } else if (nread == 0) {
+            ++timeouts;
+        } else if (errno != EINTR) {
+            perror(PROGRAM_NAME ": read");
+            goto restore;
+        }
+    }
+
+    if (!done) {
+        fprintf(stderr, PROGRAM_NAME ": failed to read cursor position response\n");
+        goto restore;
+    }
+
+    response[len] = '\0';
+
+    if (sscanf(response, "\033[%d;%dR", out_row, out_col) != 2) {
+        fprintf(stderr, PROGRAM_NAME ": unexpected response '%s'\n", response);
+        goto restore;
+    }
+
+    status = 0;
+
+restore:
+    if (restore_terminal(STDIN_FILENO, &orig) == -1)
+        status = -1;
+
+    return status;
+}
+
+int main(void) {
+    int row = 0;
+    int col = 0;
+
+    if (query_cursor_position(&row, &col) != 0)
+        return EXIT_FAILURE;
+
+    printf("%d\n", col);
+    return EXIT_SUCCESS;
+}
+

--- a/commands/_GETCOL.c
+++ b/commands/_GETCOL.c
@@ -1,116 +1,30 @@
 #define _POSIX_C_SOURCE 200809L
 
+#include "../lib/cursorpos.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <termios.h>
-#include <unistd.h>
 
-#define PROGRAM_NAME "_GETCOL"
-
-static int restore_terminal(int fd, const struct termios *orig) {
-    if (tcsetattr(fd, TCSANOW, orig) == -1) {
-        perror(PROGRAM_NAME ": tcsetattr");
-        return -1;
+static void report_error(const char *program) {
+    if (errno == ETIMEDOUT) {
+        fprintf(stderr, "%s: timed out while waiting for cursor position\n", program);
+    } else if (errno == EILSEQ) {
+        fprintf(stderr, "%s: unexpected cursor position response\n", program);
+    } else {
+        perror(program);
     }
-    return 0;
-}
-
-static int query_cursor_position(int *out_row, int *out_col) {
-    if (out_row == NULL || out_col == NULL) {
-        errno = EINVAL;
-        perror(PROGRAM_NAME ": invalid output pointer");
-        return -1;
-    }
-
-    if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) {
-        fprintf(stderr, PROGRAM_NAME ": stdin and stdout must be a terminal\n");
-        return -1;
-    }
-
-    struct termios orig;
-    if (tcgetattr(STDIN_FILENO, &orig) == -1) {
-        perror(PROGRAM_NAME ": tcgetattr");
-        return -1;
-    }
-
-    struct termios raw = orig;
-    raw.c_lflag &= ~(ICANON | ECHO);
-    raw.c_cc[VMIN] = 0;
-    raw.c_cc[VTIME] = 10; /* 1 second timeout */
-
-    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) == -1) {
-        perror(PROGRAM_NAME ": tcsetattr");
-        return -1;
-    }
-
-    int status = -1;
-
-    if (fflush(stdout) == EOF) {
-        perror(PROGRAM_NAME ": fflush");
-        goto restore;
-    }
-
-    const char query[] = "\033[6n";
-    ssize_t written = write(STDOUT_FILENO, query, sizeof(query) - 1);
-    if (written != (ssize_t)(sizeof(query) - 1)) {
-        if (written == -1)
-            perror(PROGRAM_NAME ": write");
-        else
-            fprintf(stderr, PROGRAM_NAME ": short write when querying cursor\n");
-        goto restore;
-    }
-
-    char response[64];
-    size_t len = 0;
-    int timeouts = 0;
-    int done = 0;
-
-    while (len < sizeof(response) - 1 && timeouts < 5) {
-        ssize_t nread = read(STDIN_FILENO, response + len, sizeof(response) - 1 - len);
-        if (nread > 0) {
-            len += (size_t)nread;
-            if (response[len - 1] == 'R') {
-                done = 1;
-                break;
-            }
-        } else if (nread == 0) {
-            ++timeouts;
-        } else if (errno != EINTR) {
-            perror(PROGRAM_NAME ": read");
-            goto restore;
-        }
-    }
-
-    if (!done) {
-        fprintf(stderr, PROGRAM_NAME ": failed to read cursor position response\n");
-        goto restore;
-    }
-
-    response[len] = '\0';
-
-    if (sscanf(response, "\033[%d;%dR", out_row, out_col) != 2) {
-        fprintf(stderr, PROGRAM_NAME ": unexpected response '%s'\n", response);
-        goto restore;
-    }
-
-    status = 0;
-
-restore:
-    if (restore_terminal(STDIN_FILENO, &orig) == -1)
-        status = -1;
-
-    return status;
 }
 
 int main(void) {
     int row = 0;
     int col = 0;
 
-    if (query_cursor_position(&row, &col) != 0)
+    if (cursorpos_query(&row, &col) != 0) {
+        report_error("_GETCOL");
         return EXIT_FAILURE;
+    }
 
     printf("%d\n", col);
     return EXIT_SUCCESS;
 }
-

--- a/commands/_GETROW.c
+++ b/commands/_GETROW.c
@@ -1,116 +1,30 @@
 #define _POSIX_C_SOURCE 200809L
 
+#include "../lib/cursorpos.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <termios.h>
-#include <unistd.h>
 
-#define PROGRAM_NAME "_GETROW"
-
-static int restore_terminal(int fd, const struct termios *orig) {
-    if (tcsetattr(fd, TCSANOW, orig) == -1) {
-        perror(PROGRAM_NAME ": tcsetattr");
-        return -1;
+static void report_error(const char *program) {
+    if (errno == ETIMEDOUT) {
+        fprintf(stderr, "%s: timed out while waiting for cursor position\n", program);
+    } else if (errno == EILSEQ) {
+        fprintf(stderr, "%s: unexpected cursor position response\n", program);
+    } else {
+        perror(program);
     }
-    return 0;
-}
-
-static int query_cursor_position(int *out_row, int *out_col) {
-    if (out_row == NULL || out_col == NULL) {
-        errno = EINVAL;
-        perror(PROGRAM_NAME ": invalid output pointer");
-        return -1;
-    }
-
-    if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) {
-        fprintf(stderr, PROGRAM_NAME ": stdin and stdout must be a terminal\n");
-        return -1;
-    }
-
-    struct termios orig;
-    if (tcgetattr(STDIN_FILENO, &orig) == -1) {
-        perror(PROGRAM_NAME ": tcgetattr");
-        return -1;
-    }
-
-    struct termios raw = orig;
-    raw.c_lflag &= ~(ICANON | ECHO);
-    raw.c_cc[VMIN] = 0;
-    raw.c_cc[VTIME] = 10; /* 1 second timeout */
-
-    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) == -1) {
-        perror(PROGRAM_NAME ": tcsetattr");
-        return -1;
-    }
-
-    int status = -1;
-
-    if (fflush(stdout) == EOF) {
-        perror(PROGRAM_NAME ": fflush");
-        goto restore;
-    }
-
-    const char query[] = "\033[6n";
-    ssize_t written = write(STDOUT_FILENO, query, sizeof(query) - 1);
-    if (written != (ssize_t)(sizeof(query) - 1)) {
-        if (written == -1)
-            perror(PROGRAM_NAME ": write");
-        else
-            fprintf(stderr, PROGRAM_NAME ": short write when querying cursor\n");
-        goto restore;
-    }
-
-    char response[64];
-    size_t len = 0;
-    int timeouts = 0;
-    int done = 0;
-
-    while (len < sizeof(response) - 1 && timeouts < 5) {
-        ssize_t nread = read(STDIN_FILENO, response + len, sizeof(response) - 1 - len);
-        if (nread > 0) {
-            len += (size_t)nread;
-            if (response[len - 1] == 'R') {
-                done = 1;
-                break;
-            }
-        } else if (nread == 0) {
-            ++timeouts;
-        } else if (errno != EINTR) {
-            perror(PROGRAM_NAME ": read");
-            goto restore;
-        }
-    }
-
-    if (!done) {
-        fprintf(stderr, PROGRAM_NAME ": failed to read cursor position response\n");
-        goto restore;
-    }
-
-    response[len] = '\0';
-
-    if (sscanf(response, "\033[%d;%dR", out_row, out_col) != 2) {
-        fprintf(stderr, PROGRAM_NAME ": unexpected response '%s'\n", response);
-        goto restore;
-    }
-
-    status = 0;
-
-restore:
-    if (restore_terminal(STDIN_FILENO, &orig) == -1)
-        status = -1;
-
-    return status;
 }
 
 int main(void) {
     int row = 0;
     int col = 0;
 
-    if (query_cursor_position(&row, &col) != 0)
+    if (cursorpos_query(&row, &col) != 0) {
+        report_error("_GETROW");
         return EXIT_FAILURE;
+    }
 
     printf("%d\n", row);
     return EXIT_SUCCESS;
 }
-

--- a/commands/_GETROW.c
+++ b/commands/_GETROW.c
@@ -1,0 +1,116 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <termios.h>
+#include <unistd.h>
+
+#define PROGRAM_NAME "_GETROW"
+
+static int restore_terminal(int fd, const struct termios *orig) {
+    if (tcsetattr(fd, TCSANOW, orig) == -1) {
+        perror(PROGRAM_NAME ": tcsetattr");
+        return -1;
+    }
+    return 0;
+}
+
+static int query_cursor_position(int *out_row, int *out_col) {
+    if (out_row == NULL || out_col == NULL) {
+        errno = EINVAL;
+        perror(PROGRAM_NAME ": invalid output pointer");
+        return -1;
+    }
+
+    if (!isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) {
+        fprintf(stderr, PROGRAM_NAME ": stdin and stdout must be a terminal\n");
+        return -1;
+    }
+
+    struct termios orig;
+    if (tcgetattr(STDIN_FILENO, &orig) == -1) {
+        perror(PROGRAM_NAME ": tcgetattr");
+        return -1;
+    }
+
+    struct termios raw = orig;
+    raw.c_lflag &= ~(ICANON | ECHO);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 10; /* 1 second timeout */
+
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) == -1) {
+        perror(PROGRAM_NAME ": tcsetattr");
+        return -1;
+    }
+
+    int status = -1;
+
+    if (fflush(stdout) == EOF) {
+        perror(PROGRAM_NAME ": fflush");
+        goto restore;
+    }
+
+    const char query[] = "\033[6n";
+    ssize_t written = write(STDOUT_FILENO, query, sizeof(query) - 1);
+    if (written != (ssize_t)(sizeof(query) - 1)) {
+        if (written == -1)
+            perror(PROGRAM_NAME ": write");
+        else
+            fprintf(stderr, PROGRAM_NAME ": short write when querying cursor\n");
+        goto restore;
+    }
+
+    char response[64];
+    size_t len = 0;
+    int timeouts = 0;
+    int done = 0;
+
+    while (len < sizeof(response) - 1 && timeouts < 5) {
+        ssize_t nread = read(STDIN_FILENO, response + len, sizeof(response) - 1 - len);
+        if (nread > 0) {
+            len += (size_t)nread;
+            if (response[len - 1] == 'R') {
+                done = 1;
+                break;
+            }
+        } else if (nread == 0) {
+            ++timeouts;
+        } else if (errno != EINTR) {
+            perror(PROGRAM_NAME ": read");
+            goto restore;
+        }
+    }
+
+    if (!done) {
+        fprintf(stderr, PROGRAM_NAME ": failed to read cursor position response\n");
+        goto restore;
+    }
+
+    response[len] = '\0';
+
+    if (sscanf(response, "\033[%d;%dR", out_row, out_col) != 2) {
+        fprintf(stderr, PROGRAM_NAME ": unexpected response '%s'\n", response);
+        goto restore;
+    }
+
+    status = 0;
+
+restore:
+    if (restore_terminal(STDIN_FILENO, &orig) == -1)
+        status = -1;
+
+    return status;
+}
+
+int main(void) {
+    int row = 0;
+    int col = 0;
+
+    if (query_cursor_position(&row, &col) != 0)
+        return EXIT_FAILURE;
+
+    printf("%d\n", row);
+    return EXIT_SUCCESS;
+}
+

--- a/lib/cursorpos.c
+++ b/lib/cursorpos.c
@@ -1,0 +1,154 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "cursorpos.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <termios.h>
+#include <unistd.h>
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+static int write_all(int fd, const char *data, size_t len) {
+    size_t written = 0;
+    while (written < len) {
+        ssize_t rc = write(fd, data + written, len - written);
+        if (rc > 0) {
+            written += (size_t)rc;
+            continue;
+        }
+        if (rc == -1 && errno == EINTR)
+            continue;
+        return -1;
+    }
+    return 0;
+}
+
+int cursorpos_query(int *row_out, int *col_out) {
+    if (row_out == NULL || col_out == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    int fd = open("/dev/tty", O_RDWR | O_NOCTTY | O_CLOEXEC);
+    if (fd == -1)
+        return -1;
+
+    struct termios original;
+    if (tcgetattr(fd, &original) == -1) {
+        close(fd);
+        return -1;
+    }
+
+    struct termios raw = original;
+    raw.c_lflag &= ~(ICANON | ECHO | ISIG | IEXTEN);
+    raw.c_iflag &= ~(IXON | ICRNL | BRKINT | INPCK | ISTRIP);
+    raw.c_oflag &= ~(OPOST);
+    raw.c_cflag |= CS8;
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 1; /* 100ms units */
+
+    if (tcsetattr(fd, TCSANOW, &raw) == -1) {
+        close(fd);
+        return -1;
+    }
+
+    int ret = -1;
+
+    if (tcflush(fd, TCIFLUSH) == -1)
+        goto restore;
+
+    static const char query[] = "\033[6n";
+    if (write_all(fd, query, sizeof(query) - 1) == -1)
+        goto restore;
+
+    char response[64];
+    size_t len = 0;
+    int timeouts = 0;
+
+    while (len < sizeof(response) - 1) {
+        char ch;
+        ssize_t rc = read(fd, &ch, 1);
+        if (rc == 1) {
+            response[len++] = ch;
+            if (ch == 'R')
+                break;
+        } else if (rc == 0) {
+            if (++timeouts >= 20) {
+                errno = ETIMEDOUT;
+                goto restore;
+            }
+        } else if (rc == -1 && errno == EINTR) {
+            continue;
+        } else {
+            goto restore;
+        }
+    }
+
+    if (len == 0 || response[len - 1] != 'R') {
+        errno = ETIMEDOUT;
+        goto restore;
+    }
+
+    response[len] = '\0';
+
+    char *cursor = response;
+    while (*cursor == '\r' || *cursor == '\n')
+        ++cursor;
+
+    if (*cursor == '\033')
+        ++cursor;
+
+    if (*cursor != '[') {
+        errno = EILSEQ;
+        goto restore;
+    }
+    ++cursor;
+
+    char *endptr = NULL;
+    errno = 0;
+    long row = strtol(cursor, &endptr, 10);
+    if (errno != 0 || endptr == cursor || row < INT_MIN || row > INT_MAX) {
+        errno = EILSEQ;
+        goto restore;
+    }
+    if (*endptr != ';') {
+        errno = EILSEQ;
+        goto restore;
+    }
+    cursor = endptr + 1;
+
+    errno = 0;
+    long col = strtol(cursor, &endptr, 10);
+    if (errno != 0 || endptr == cursor || col < INT_MIN || col > INT_MAX) {
+        errno = EILSEQ;
+        goto restore;
+    }
+    if (*endptr != 'R') {
+        errno = EILSEQ;
+        goto restore;
+    }
+
+    *row_out = (int)row;
+    *col_out = (int)col;
+    ret = 0;
+
+restore:
+    {
+        int saved_errno = errno;
+        if (tcsetattr(fd, TCSANOW, &original) == -1 && ret == 0) {
+            saved_errno = errno;
+            ret = -1;
+        }
+        if (close(fd) == -1 && ret == 0) {
+            saved_errno = errno;
+            ret = -1;
+        }
+        errno = saved_errno;
+    }
+    return ret;
+}

--- a/lib/cursorpos.h
+++ b/lib/cursorpos.h
@@ -1,0 +1,6 @@
+#ifndef CURSORPOS_H
+#define CURSORPOS_H
+
+int cursorpos_query(int *row_out, int *col_out);
+
+#endif /* CURSORPOS_H */


### PR DESCRIPTION
## Summary
- add a _GETROW command that queries the terminal and prints the current cursor row
- add a matching _GETCOL command that reports the current cursor column
- temporarily switch stdin to raw mode to read the cursor position response safely

## Testing
- make *(fails: missing -lasound on the build host)*

------
https://chatgpt.com/codex/tasks/task_e_68e4de5f3f48832788c9d321d762474f